### PR TITLE
fix addTrigger's max algo - cast idx attr to num

### DIFF
--- a/index.php
+++ b/index.php
@@ -79,9 +79,9 @@ print $calT->renderHelpDivs();
 	    max = 0;
 	    $('div.trigger', '#triggers_config').each(
 		    function (index,value) {
-			    idx = $(this).attr('idx');
-			    if ($(this).attr('idx') > max) {
-				    max = $(this).attr('idx');
+			    idx = +$(this).attr('idx');
+			    if (idx > max) {
+				    max = idx;
 			    };
 		    }
 	    );


### PR DESCRIPTION
The addTrigger function's max finding algorithm was using a string, as that is what `$.attr()` returns. Using the unary + operator we can coerce it back into an integer. This allows the algorithm to work properly. Otherwise, it'll think "10" comes before "9". Also, let's actually use the idx variable instead of using `$.attr()` multiple times.